### PR TITLE
enums broken with Rails 2.3

### DIFF
--- a/lib/symbolize.rb
+++ b/lib/symbolize.rb
@@ -71,7 +71,8 @@ module Symbolize
           if enum.is_a?(Hash)
             values = enum
           else
-            values = hsh[*enum.map { |v| [v, (configuration[:capitalize] ? v.to_s.capitalize : v.to_s)] }.flatten]
+            values = hsh.new
+            enum.map { |v| [v, (configuration[:capitalize] ? v.to_s.capitalize : v.to_s)] }.each { |k, v| values[k] = v }
           end
 
           # Get the values of :in


### PR DESCRIPTION
At least in Rails 2.3.2 - ActiveSupport::OrderedHash[*values] does not properly initialize the object - it does not fill up the @keys ivar, so hash#keys, hash#each, and any other method that references @keys is broken.
