### PR TITLE
Do not attempt to call empty? on a symbol (fixes tests)

### DIFF
--- a/lib/symbolize.rb
+++ b/lib/symbolize.rb
@@ -161,7 +161,14 @@ module Symbolize
   def write_symbolized_attribute attr_name, value
     val = { "true" => true, "false" => false }[value]
     val = symbolize_attribute(value) if val.nil?
-    self[attr_name] = val
+
+    current_value = self.send(attr_name)
+    if current_value == val
+      current_value
+    else
+      self[attr_name] = val
+      val
+    end
   end
 end
 

--- a/lib/symbolize.rb
+++ b/lib/symbolize.rb
@@ -119,7 +119,7 @@ module Symbolize
 
         if default_option
           class_eval("def #{attr_name}; read_and_symbolize_attribute('#{attr_name}') || :#{default_option}; end")
-          class_eval("def #{attr_name}= (value); write_symbolized_attribute('#{attr_name}', (value && !value.empty? ? value : #{default_option})); end")
+          class_eval("def #{attr_name}= (value); write_symbolized_attribute('#{attr_name}', value); end")
           class_eval("def set_default_for_attr_#{attr_name}; self[:#{attr_name}] ||= :#{default_option}; end")
           class_eval("before_save :set_default_for_attr_#{attr_name}")
         else

--- a/spec/symbolize_spec.rb
+++ b/spec/symbolize_spec.rb
@@ -68,7 +68,7 @@ describe "Symbolize" do
     it "test_symbolize_symbol" do
       @user.status = :active
       @user.status.should eql(:active)
-      @user.status_before_type_cast.should eql(:active)
+      @user.status_before_type_cast.should eql('active')
       # @user.read_attribute(:status).should eql('active')
     end
 
@@ -317,7 +317,7 @@ describe "Symbolize" do
     #
     #  ActiveRecord <= 2
     #
-    if ActiveRecord::VERSION::MAJOR < 3
+    if ActiveRecord::VERSION::MAJOR <= 2
 
       it "test_symbolized_finder" do
         User.find(:all, :conditions => { :status => :inactive }).map(&:name).should eql(['Bob'])
@@ -327,6 +327,30 @@ describe "Symbolize" do
       it "test_symbolized_with_scope" do
         User.with_scope(:find => { :conditions => { :status => :inactive }}) do
           User.find(:all).map(&:name).should eql(['Bob'])
+        end
+      end
+
+      describe "dirty tracking / changed flag" do
+        before do
+          @anna = User.find_by_name!('Anna')
+        end
+
+        it "is dirty if you change the attribute value" do
+          @anna.language.should == :pt
+          @anna.language_changed?.should be_false
+
+          return_value = @anna.language = :en
+          return_value.should == :en
+          @anna.language_changed?.should be_true
+        end
+
+        it "is not dirty if you set the attribute value to the same value it was originally" do
+          @anna.language.should == :pt
+          @anna.language_changed?.should be_false
+
+          return_value = @anna.language = :pt
+          return_value.should == :pt
+          @anna.language_changed?.should be_false
         end
       end
 
@@ -343,6 +367,30 @@ describe "Symbolize" do
       it "test_symbolized_with_scope" do
         User.with_scope(:find => { :conditions => { :status => :inactive }}) do
           User.find(:all).map(&:name).should eql(['Bob'])
+        end
+      end
+
+      describe "dirty tracking / changed flag" do
+        before do
+          @anna = User.find_by_name!('Anna')
+        end
+
+        it "is dirty if you change the attribute value" do
+          @anna.language.should == :pt
+          @anna.language_changed?.should be_false
+
+          return_value = @anna.language = :en
+          return_value.should == :en
+          @anna.language_changed?.should be_true
+        end
+
+        it "is not dirty if you set the attribute value to the same value it was originally" do
+          @anna.language.should == :pt
+          @anna.language_changed?.should be_false
+
+          return_value = @anna.language = :pt
+          return_value.should == :pt
+          @anna.language_changed?.should be_false
         end
       end
 


### PR DESCRIPTION
Currently the test suite is failing because if a symbol is passed to the setter method it will call `empty?` which is not defined for symbols.

We changed the line back to the way it used to be and the tests pass again. This changes the behavior slightly. Before if a default option was specified setting the attribute to `nil` would instead assign `default_option`.
