### PR TITLE
Revised/simplified the way the I18n option work.

### DIFF
--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -100,7 +100,7 @@ module Symbolize
             scope_comm = lambda { |*args| ActiveRecord::VERSION::MAJOR >= 3 ? scope(*args) : named_scope(*args)}
             values.each do |value|
               if value[0].respond_to?(:to_sym)
-                scope_comm.call value[0].to_sym, :conditions => { attr_name => value[0].to_sym }
+                scope_comm.call value[0].to_sym, :conditions => { attr_name => value[0].to_s }
               elsif ActiveRecord::VERSION::STRING <= "3.0"
                 if value[0] == true || value[0] == false
                   scope_comm.call "with_#{attr_name}".to_sym,    :conditions => { attr_name => '1' }

--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -100,7 +100,7 @@ module Symbolize
             scope_comm = lambda { |*args| ActiveRecord::VERSION::MAJOR >= 3 ? scope(*args) : named_scope(*args)}
             values.each do |value|
               if value[0].respond_to?(:to_sym)
-                scope_comm.call value[0].to_sym, :conditions => { attr_name => value[0].to_s }
+                scope_comm.call value[0].to_sym, :conditions => { attr_name => value[1].to_s }
               elsif ActiveRecord::VERSION::STRING <= "3.0"
                 if value[0] == true || value[0] == false
                   scope_comm.call "with_#{attr_name}".to_sym,    :conditions => { attr_name => '1' }
@@ -115,7 +115,7 @@ module Symbolize
 
           if validation
             validation = "validates_inclusion_of :#{attr_names.join(', :')}"
-            validation += ", :in => #{values.keys.inspect}"
+            validation += ", :in => #{values.values.inspect}"
             validation += ", :allow_nil => true" if configuration[:allow_nil]
             validation += ", :allow_blank => true" if configuration[:allow_blank]
             class_eval validation

--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -171,7 +171,7 @@ module Symbolize
     val = { "true" => true, "false" => false }[value]
     val = symbolize_attribute(value) if val.nil?
 
-    self[attr_name] = val #.to_s # rails 3.1 fix
+    self[attr_name] = val.to_s
   end
 end
 

--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -131,17 +131,15 @@ module Symbolize
 
         if default_option
           class_eval("def #{attr_name}; read_and_symbolize_attribute(#{attr_name.to_s.upcase}_KEYS, '#{attr_name}') || :#{default_option}; end")
-          class_eval("def #{attr_name}= (value); write_symbolized_attribute('#{attr_name}', value); end")
+          class_eval("def #{attr_name}= (value); write_symbolized_attribute('#{attr_name}', #{attr_name.to_s.upcase}_VALUES[value]); end")
           class_eval("def set_default_for_attr_#{attr_name}; self[:#{attr_name}] ||= :#{default_option}; end")
           class_eval("before_save :set_default_for_attr_#{attr_name}")
         else
           class_eval("def #{attr_name}; read_and_symbolize_attribute(#{attr_name.to_s.upcase}_KEYS, '#{attr_name}'); end")
-          class_eval("def #{attr_name}= (value); write_symbolized_attribute('#{attr_name}', value); end")
+          class_eval("def #{attr_name}= (value); write_symbolized_attribute('#{attr_name}', #{attr_name.to_s.upcase}_VALUES[value]); end")
         end
         if i18n
           class_eval("def #{attr_name}_text; read_i18n_attribute(#{attr_name.to_s.upcase}_KEYS, '#{attr_name}'); end")
-        elsif enum
-          class_eval("def #{attr_name}_text; #{attr_name.to_s.upcase}_VALUES[#{attr_name}]; end")
         else
           class_eval("def #{attr_name}_text; #{attr_name}.to_s; end")
         end
@@ -172,8 +170,7 @@ module Symbolize
 
   # Write a symbolized value. Watch out for booleans.
   def write_symbolized_attribute attr_name, value
-    val = { "true" => true, "false" => false }[value]
-    self[attr_name] = val.nil? ? nil : val.to_s
+    self[attr_name] = value.nil? ? nil : value.to_s
   end
 end
 

--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -170,7 +170,7 @@ module Symbolize
 
   # Write a symbolized value. Watch out for booleans.
   def write_symbolized_attribute attr_name, value
-    self[attr_name] = value.nil? ? nil : value.to_s
+    self[attr_name] = value
   end
 end
 

--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -119,7 +119,7 @@ module Symbolize
 
           if validation
             validation = "validates_inclusion_of :#{attr_names.join(', :')}"
-            validation += ", :in => #{values.values.inspect}"
+            validation += ", :in => #{values.keys.inspect}"
             validation += ", :allow_nil => true" if configuration[:allow_nil]
             validation += ", :allow_blank => true" if configuration[:allow_blank]
             class_eval validation

--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -52,7 +52,7 @@ module Symbolize
       configuration.update(attr_names.extract_options!)
 
       enum = configuration[:in] || configuration[:within]
-      i18n = configuration.delete(:i18n).nil? && !enum.instance_of?(Hash) && enum ? true : configuration[:i18n]
+      i18n = configuration[:i18n].nil? || configuration.delete(:i18n)
       scopes  = configuration.delete :scopes
       methods = configuration.delete :methods
       capitalize = configuration.delete :capitalize
@@ -163,7 +163,7 @@ module Symbolize
   def read_i18n_attribute attr_name
     attr = read_attribute(attr_name)
     return nil if attr.nil?
-    I18n.translate("activerecord.attributes.#{ActiveSupport::Inflector.underscore(self.class)}.enums.#{attr_name}.#{attr}") #.to_sym rescue nila
+    I18n.translate("activerecord.attributes.#{ActiveSupport::Inflector.underscore(self.class)}.enums.#{attr_name}.#{attr}")
   end
 
   # Write a symbolized value. Watch out for booleans.

--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -130,12 +130,12 @@ module Symbolize
       attr_names.each do |attr_name|
 
         if default_option
-          class_eval("def #{attr_name}; read_and_symbolize_attribute('#{attr_name}') || :#{default_option}; end")
+          class_eval("def #{attr_name}; read_and_symbolize_attribute(#{attr_name.to_s.upcase}_KEYS, '#{attr_name}') || :#{default_option}; end")
           class_eval("def #{attr_name}= (value); write_symbolized_attribute('#{attr_name}', value); end")
           class_eval("def set_default_for_attr_#{attr_name}; self[:#{attr_name}] ||= :#{default_option}; end")
           class_eval("before_save :set_default_for_attr_#{attr_name}")
         else
-          class_eval("def #{attr_name}; read_and_symbolize_attribute('#{attr_name}'); end")
+          class_eval("def #{attr_name}; read_and_symbolize_attribute(#{attr_name.to_s.upcase}_KEYS, '#{attr_name}'); end")
           class_eval("def #{attr_name}= (value); write_symbolized_attribute('#{attr_name}', value); end")
         end
         if i18n
@@ -150,32 +150,30 @@ module Symbolize
   end
 
   # String becomes symbol, booleans string and nil nil.
-  def symbolize_attribute attr
+  def symbolize_attribute keys_by_values, attr
     case attr
-      when String then attr.empty? ? nil : attr.to_sym
+      when String then attr.empty? ? nil : keys_by_values[attr]
       when Symbol, TrueClass, FalseClass, Numeric then attr
       else nil
     end
   end
 
   # Return an attribute's value as a symbol or nil
-  def read_and_symbolize_attribute attr_name
-    symbolize_attribute self[attr_name]
+  def read_and_symbolize_attribute keys_by_values, attr_name
+    symbolize_attribute keys_by_values, self[attr_name]
   end
 
   # Return an attribute's i18n
   def read_i18n_attribute keys_by_values, attr_name
     attr = keys_by_values[read_attribute(attr_name)]
     return nil if attr.nil?
-    I18n.translate("activerecord.attributes.#{ActiveSupport::Inflector.underscore(self.class)}.enums.#{attr_name}.#{attr}")
+    I18n.translate("activerecord.attributes.#{ActiveSupport::Inflector.underscore(self.class)}.#{attr_name}/#{attr}")
   end
 
   # Write a symbolized value. Watch out for booleans.
   def write_symbolized_attribute attr_name, value
     val = { "true" => true, "false" => false }[value]
-    val = symbolize_attribute(value) if val.nil?
-
-    self[attr_name] = val.to_s
+    self[attr_name] = val.nil? ? nil : val.to_s
   end
 end
 


### PR DESCRIPTION
With this patch, it's true by default, no matter the type of the enum. This has been done because the value I use in the enums are often tied to other third-party system which isn't human readable text. Human readable text should always be constrained to the locale files anyway.

P.S.: It also contain the commits from my other pull request as I was too lazy to create another branch!
