### PR TITLE
Use model_name in <attribute>_text helper

### DIFF
--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -158,7 +158,7 @@ module Symbolize
   def read_i18n_attribute attr_name
     attr = read_attribute(attr_name)
     return nil if attr.nil?
-    I18n.translate("activerecord.attributes.#{ActiveSupport::Inflector.underscore(self.class)}.enums.#{attr_name}.#{attr}") #.to_sym rescue nila
+    I18n.translate("activerecord.attributes.#{ActiveSupport::Inflector.underscore(self.class.model_name)}.enums.#{attr_name}.#{attr}") #.to_sym rescue nila
   end
 
   # Write a symbolized value. Watch out for booleans.

--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -80,7 +80,7 @@ module Symbolize
           const_set const.upcase, values unless const_defined? const.upcase
           ev = if i18n
             # This one is a dropdown helper
-            code =  "#{const.upcase}.map { |k,v| [I18n.translate(\"activerecord.attributes.\#{ActiveSupport::Inflector.underscore(self)}.enums.#{attr_name}.\#{k}\"), k] }" #.to_sym rescue nila
+            code =  "#{const.upcase}.map { |k,v| [I18n.translate(\"activerecord.attributes.\#{ActiveSupport::Inflector.underscore(self.model_name)}.enums.#{attr_name}.\#{k}\"), k] }" #.to_sym rescue nila
             "def self.get_#{const}; #{code}; end;"
           else
             "def self.get_#{const}; #{const.upcase}.map(&:reverse); end"

--- a/lib/symbolize/mongoid.rb
+++ b/lib/symbolize/mongoid.rb
@@ -130,7 +130,7 @@ module Mongoid
           if i18n # memoize call to translate... good idea?
             define_method "#{attr_name}_text" do
               return nil unless attr = read_attribute(attr_name)
-              I18n.t("mongoid.attributes.#{ActiveSupport::Inflector.underscore(self.class)}.enums.#{attr_name}.#{attr}")
+              I18n.t("mongoid.attributes.#{ActiveSupport::Inflector.underscore(self.class.model_name)}.enums.#{attr_name}.#{attr}")
             end
           elsif enum
             class_eval("def #{attr_name}_text; #{attr_name.to_s.upcase}_VALUES[#{attr_name}]; end")

--- a/lib/symbolize/mongoid.rb
+++ b/lib/symbolize/mongoid.rb
@@ -89,7 +89,7 @@ module Mongoid
             const_set const.upcase, values unless const_defined? const.upcase
             ev = if i18n
                    # This one is a dropdown helper
-                   code =  "#{const.upcase}.map { |k,v| [I18n.t(\"mongoid.attributes.\#{ActiveSupport::Inflector.underscore(self)}.enums.#{attr_name}.\#{k}\"), k] }" #.to_sym rescue nila
+                   code =  "#{const.upcase}.map { |k,v| [I18n.t(\"mongoid.attributes.\#{ActiveSupport::Inflector.underscore(self.model_name)}.enums.#{attr_name}.\#{k}\"), k] }" #.to_sym rescue nila
                    "def self.get_#{const}; #{code}; end;"
                  else
                    "def self.get_#{const}; #{const.upcase}.map(&:reverse); end"


### PR DESCRIPTION
Currently, the helper uses `self.class` when looking up the translation key. When using single table inheritance, this means that you need to repeat your translations for all the inheriting models.

In my commit, I have changed this to `self.class.model_name` which by default makes no difference, but which lets you override `model_name` in the parent class if you wish, which will make all the inheriting models use the parent model's name for the translation lookup.

All tests pass.
