### PR TITLE
Mongoid: it should return the proper 'false' i18n if the attr value is 'false'.

### DIFF
--- a/lib/symbolize/mongoid.rb
+++ b/lib/symbolize/mongoid.rb
@@ -130,7 +130,8 @@ module Mongoid
         attr_names.each do |attr_name|
           if i18n # memoize call to translate... good idea?
             define_method "#{attr_name}_text" do
-              return nil unless attr = read_attribute(attr_name)
+              attr = read_attribute(attr_name)
+              return nil if attr.nil?
               I18n.t("mongoid.symbolizes.#{ActiveSupport::Inflector.underscore(self.class.model_name)}.#{attr_name}.#{attr}")
             end
           elsif enum

--- a/spec/symbolize/mongoid_spec.rb
+++ b/spec/symbolize/mongoid_spec.rb
@@ -249,6 +249,11 @@ describe "Symbolize" do
         skill.kind_text.should be_nil
       end
 
+      it "should return the proper 'false' i18n if the attr value is false" do
+        person = Person.new(:sex => false)
+        person.sex_text.should == "Masculino"
+      end
+
     end
 
     describe "Methods" do


### PR DESCRIPTION
There was this bug causing 'false' switches not to i18n correctly because the return condition discarded false values.
