### PR TITLE
Bugfix: Methods on non-saved objects should return the correct value

### DIFF
--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -90,7 +90,7 @@ module Symbolize
             values.each do |value|
               key = value[0]
               define_method("#{key}?") do
-                self[attr_name].to_s == key.to_s
+                self.send(attr_name).to_s == key.to_s
               end
             end
           end

--- a/spec/db/001_create_testing_structure.rb
+++ b/spec/db/001_create_testing_structure.rb
@@ -8,6 +8,7 @@ class CreateTestingStructure < ActiveRecord::Migration
       t.boolean :sex
       t.boolean :public
       t.boolean :cool
+      t.string :color
     end
     create_table :user_skills do |t|
       t.references :user

--- a/spec/symbolize/active_record_spec.rb
+++ b/spec/symbolize/active_record_spec.rb
@@ -16,6 +16,7 @@ class User < ActiveRecord::Base
   symbolize :gui, :allow_blank => true, :in => [:cocoa, :qt, :gtk], :i18n => false
   symbolize :karma, :in => %w{ good bad ugly}, :methods => true, :i18n => false, :allow_nil => true
   symbolize :cool, :in => [true, false], :scopes => true
+  symbolize :color, :in => [:red, :green, :blue], :default => :red, :methods => true
 
   has_many :extras, :dependent => :destroy, :class_name => "UserExtra"
   has_many :access, :dependent => :destroy, :class_name => "UserAccess"
@@ -60,6 +61,13 @@ describe "Symbolize" do
     u.errors.messages.should eql({})
     u.status.should eql(:active)
     u.should be_active
+  end
+  
+  describe "User non-persisted" do
+    it "should work with methods with default value" do
+      @user = User.new
+      @user.should be_red
+    end
   end
 
   describe "User Instantiated" do


### PR DESCRIPTION
This fixes method behaviors on non-saved objects.

Given:

``` ruby
class User
  symbolize :color, :in => [:red, :blue], :default => :red
end
```

Before:

``` ruby
@u = User.new

@u.color
=> :red

@u.red?
=> false
```

After:

``` ruby
@u.red?
=> true
```
