### PR TITLE
Add enum helpers for RailsAdmin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    symbolize (4.2.0)
+    symbolize (4.2.1)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -85,6 +85,7 @@ module Symbolize
             "def self.get_#{const}; #{const.upcase}.map(&:reverse); end"
           end
           class_eval(ev)
+          class_eval "def #{attr_name}_enum; self.class.get_#{const}; end"
 
           if methods
             values.each do |value|

--- a/lib/symbolize/mongoid.rb
+++ b/lib/symbolize/mongoid.rb
@@ -96,6 +96,7 @@ module Mongoid
                    "def self.get_#{const}; #{const.upcase}.map(&:reverse); end"
                  end
             class_eval(ev)
+            class_eval "def #{attr_name}_enum; self.class.get_#{const}; end"
 
             if methods
               values.each do |value|

--- a/spec/symbolize/active_record_spec.rb
+++ b/spec/symbolize/active_record_spec.rb
@@ -120,6 +120,10 @@ describe "Symbolize" do
       User::STATUS_VALUES.should eql({:inactive=>"Inactive", :active=>"Active"})
     end
 
+    it "should get the values for RailsAdmin" do
+      @user.status_enum.should eql([["Active", :active],["Inactive", :inactive]])
+    end
+
     it "test_symbolize_humanize" do
       @user.status_text.should eql("Active")
     end

--- a/spec/symbolize/mongoid_spec.rb
+++ b/spec/symbolize/mongoid_spec.rb
@@ -131,6 +131,10 @@ describe "Symbolize" do
       Person::STATUS_VALUES.should eql({ inactive: "Inactive", active: "Active"})
     end
 
+    it "should get the values for RailsAdmin" do
+      person.status_enum.should eql([["Active", :active],["Inactive", :inactive]])
+    end
+
     it "should have a human _text method" do
       person.status_text.should eql("Active")
     end


### PR DESCRIPTION
RailsAdmin expects `options_for_select`-style enum options from an instance method called `:#{attr}_enum`. Symbolize already provides the same data from a class method called `:get_#{attr}_values`.

This patch provides the enums for RailsAdmin.
