### PR TITLE
Fixes another I18n configuration issue

### DIFF
--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -51,7 +51,8 @@ module Symbolize
       configuration.update(attr_names.extract_options!)
 
       enum = configuration[:in] || configuration[:within]
-      i18n = configuration.delete(:i18n) || (!enum.instance_of?(Hash) && enum)
+      i18n = configuration.delete(:i18n)
+      i18n = (!enum.instance_of?(Hash) && enum) if i18n.nil?
       scopes  = configuration.delete :scopes
       methods = configuration.delete :methods
       capitalize = configuration.delete :capitalize


### PR DESCRIPTION
false and nil are interpreted the same if using ||

Therefore split i18n configuration into two parts, first see if there is
a configuration, second check if enum is defined and a hash
