### PR TITLE
bug fix: was always requiring both mongoid & rails

### DIFF
--- a/lib/symbolize.rb
+++ b/lib/symbolize.rb
@@ -3,5 +3,5 @@ module Symbolize
   autoload :ActiveRecord, 'symbolize/active_record'
 end
 
-require 'symbolize/mongoid' if defined? 'Mongoid'
-require 'symbolize/railtie' if defined? 'Rails'
+require 'symbolize/mongoid' if defined? Mongoid
+require 'symbolize/railtie' if defined? Rails


### PR DESCRIPTION
the defined? guards were checking string literals rather than constants, so were always returning true.  

(for the case of Mongoid this meant that symbolize/mongoid was always being included, which as a side effect caused the constant ::Mongoid to be defined, which then broke other gems which likewise checked for the existence of that constant before doing mongo-specific things which failed because Mongoid wasn't really loaded)
