### PR TITLE
Make generated scopes compatible with Rails 4

### DIFF
--- a/lib/symbolize/active_record.rb
+++ b/lib/symbolize/active_record.rb
@@ -110,7 +110,7 @@ module Symbolize::ActiveRecord
               values.each do |value|
                 name = value[0]
                 if name.respond_to?(:to_sym)
-                  scope name.to_sym, where(attr_name => name.to_s)
+                  scope name.to_sym, -> { where(attr_name => name.to_s) }
                   # Figure out if this as another option, or default...
                   # scope_comm.call "not_#{attr_name}".to_sym, :conditions => { attr_name != name }
                 end

--- a/lib/symbolize/mongoid.rb
+++ b/lib/symbolize/mongoid.rb
@@ -111,7 +111,7 @@ module Mongoid
               if scopes == :shallow
                 values.each do |k, v|
                   if k.respond_to?(:to_sym)
-                    scope k.to_sym, where({ attr_name => k })
+                    scope k.to_sym, -> { where(attr_name => k) }
                   end
                 end
               else # scoped scopes


### PR DESCRIPTION
Rails 4 requires all scopes to use a callable object (Proc or lambda).

So this:

```
scope name.to_sym, where(attr_name => name.to_s)
```

Should now be:

```
scope name.to_sym, -> { where(attr_name => name.to_s) }
```

There are no tests for this change as I'm not really sure how to go about testing it. If you've got any suggestions please let me know and I'll add them in.
