### PR TITLE
Fix getting human text for empty string

### DIFF
--- a/lib/symbolize/mongoid.rb
+++ b/lib/symbolize/mongoid.rb
@@ -137,7 +137,7 @@ module Mongoid
           if i18n # memoize call to translate... good idea?
             define_method "#{attr_name}_text" do
               attr = read_attribute(attr_name)
-              return nil if attr.nil?
+              return nil if attr.nil? || attr.to_s.strip.length == 0
               I18n.t("mongoid.symbolizes.#{self.class.model_name.to_s.underscore}.#{attr_name}.#{attr}")
             end
           elsif enum

--- a/spec/symbolize/mongoid_spec.rb
+++ b/spec/symbolize/mongoid_spec.rb
@@ -117,6 +117,7 @@ describe "Symbolize" do
       person.karma.should be_nil
       person.save
       person.read_attribute(:karma).should be_nil
+      person.karma_text.should be_nil
     end
 
     it "should acts nice with blank" do
@@ -124,6 +125,7 @@ describe "Symbolize" do
       person.so.should be_blank
       person.save
       person.read_attribute(:so).should be_blank
+      person.so_text.should be_nil
     end
 
     it "should not validates other" do


### PR DESCRIPTION
For empty strings human text helper returns whole translation hash instead of nil.
